### PR TITLE
Fixed Unhandled exception error caused by custom attribute

### DIFF
--- a/pages/api/register.ts
+++ b/pages/api/register.ts
@@ -22,7 +22,10 @@ const register = async (req: NextApiRequest, res: NextApiResponse) => {
 
     const attributeList = [
         new CognitoUserAttribute({Name: "email", Value: req.body.email}),
-        new CognitoUserAttribute({Name: "custom:timestamp", Value: Date.now().toString()})
+       //uncomment the below line when your userpool is configured with creating a new custom attribute
+       // https://stackoverflow.com/questions/53475478/react-cognito-user-pool-a-client-attempted-to-write-unauthorized-attribute
+       // https://stackoverflow.com/questions/44013901/amazon-cognito-a-client-attempted-to-write-unauthorized-attribute
+       // new CognitoUserAttribute({Name: "custom:timestamp", Value: Date.now().toString()})
     ]
 
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
Default cognito user pool has no custom attribute

uncomment the below line when your userpool is configured with creating a new custom attribute
       https://stackoverflow.com/questions/53475478/react-cognito-user-pool-a-client-attempted-to-write-unauthorized-attribute
       https://stackoverflow.com/questions/44013901/amazon-cognito-a-client-attempted-to-write-unauthorized-attribute